### PR TITLE
Improve test_send_email

### DIFF
--- a/expirybot/sample_data/_expected_email.txt
+++ b/expirybot/sample_data/_expected_email.txt
@@ -1,0 +1,43 @@
+Hi! I'm Paul and this email was sent by a friendly robot called Expirybot.
+
+This is a reminder that your PGP key expires on Monday 04 December 2017.
+
+fingerprint: A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517
+long key id: 0x309F635DAD1B5517
+
+Here's the key listed in the MIT public keyserver:
+
+https://pgp.mit.edu/pks/lookup?op=vindex&search=0x309F635DAD1B5517
+
+== Extend your key expiry date ==
+
+You can extend your key's expiry date and push it to the keyservers.
+
+You don't need to create a new key.
+
+I've written a few short guides with screenshots for different software:
+
+- Enigmail with Thunderbird: https://www.paulfurley.com/extend-pgp-key-expiry-with-enigmail-thunderbird
+- GPG Suite (GPG Keychain): https://www.paulfurley.com/extend-pgp-key-expiry-with-gpg-suite-gpg-keychain
+- GNU Privacy Guard (GnuPG): https://www.paulfurley.com/extend-pgp-key-expiry-with-gpg
+
+(I'm currently working on Mailvelope - any others?)
+
+== Remember to push your updated key to the keyservers ==
+
+Once you've extended the expiry date, don't forget to push your key to the keyservers again so everyone can see the update.
+
+I hope this email has been helpful. If this feels like spam, I'm sorry :(
+
+Kind regards,
+
+Paul
+
+--
+Paul M Furley => Engineer / Developer
+
+Let's make it better! Trying to improve the world by making :)
+
+- Website: https://www.paulfurley.com/expirybot-emails-pgp-users-before-their-key-expires/
+- Twitter: https://twitter.com/paul_furley
+- PGP: A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517

--- a/expirybot/test_utils.py
+++ b/expirybot/test_utils.py
@@ -4,9 +4,14 @@ from os.path import dirname, join as pjoin
 
 from contextlib import contextmanager
 
+SAMPLE_DIR = pjoin(dirname(__file__), 'sample_data')
+
 
 @contextmanager
 def open_sample(name):
-    fn = pjoin(dirname(__file__), 'sample_data', name)
-    with io.open(fn, 'rb') as f:
+    with io.open(sample_filename(name), 'rb') as f:
         yield f
+
+
+def sample_filename(name):
+    return pjoin(SAMPLE_DIR, name)


### PR DESCRIPTION
Make test_send_email read an 'expected email' file to compare against
the email body, rather than testing line by line which is unusable.