### PR TITLE
Email upto 10 UIDs for each key

### DIFF
--- a/expirybot/pgp_key.py
+++ b/expirybot/pgp_key.py
@@ -152,10 +152,10 @@ class PGPKey:
 
     @property
     def emails(self):
-        return list(filter(None, map(self._parse_email, self.uids)))
+        return list(filter(None, map(self._parse_uid_as_email, self.uids)))
 
     @staticmethod
-    def _parse_email(uid):
+    def _parse_uid_as_email(uid):
         match = re.match('.*<(?P<email>.+@.+)>$', uid)
         if match:
             return match.group('email')

--- a/expirybot/pgp_key.py
+++ b/expirybot/pgp_key.py
@@ -160,6 +160,26 @@ class PGPKey:
         if match:
             return match.group('email')
 
+    @staticmethod
+    def _parse_uid_as_email_line(uid):
+        patterns = [
+            r'^(?P<name>.*?) *\(.*\) *<(?P<email>.+@.+\..+)>$',
+            r'^(?P<email>.+@.+\..+)$',  # paul@example.com
+        ]
+
+        for pattern in patterns:
+            match = re.match(pattern, uid)
+
+            if match is None:
+                continue
+
+            if match.groupdict().get('name', ''):
+                return '{} <{}>'.format(
+                    match.group('name'), match.group('email')
+                )
+            else:
+                return match.group('email')
+
     def expires_in(self, days):
         return self.days_until_expiry == days
 

--- a/expirybot/pgp_key.py
+++ b/expirybot/pgp_key.py
@@ -154,6 +154,14 @@ class PGPKey:
     def emails(self):
         return list(filter(None, map(self._parse_uid_as_email, self.uids)))
 
+    @property
+    def email_lines(self):
+
+        return list(filter(
+            None,
+            map(self._parse_uid_as_email_line, self.uids)
+        ))
+
     @staticmethod
     def _parse_uid_as_email(uid):
         match = re.match('.*<(?P<email>.+@.+)>$', uid)

--- a/expirybot/send_emails.py
+++ b/expirybot/send_emails.py
@@ -41,7 +41,7 @@ class ExpiryEmail():
             'email_subject.txt'
         ).format(**data).rstrip()
 
-        self.to = key.primary_email
+        self.to = ', '.join(key.email_lines[0:10])
         self.from_line = config.from_line
         self.reply_to = config.reply_to
 

--- a/expirybot/test_pgp_key.py
+++ b/expirybot/test_pgp_key.py
@@ -1,0 +1,17 @@
+from .pgp_key import PGPKey
+from nose.tools import assert_equal
+
+
+EMAIL_LINE_CASES = [
+    ('Paul F <paul@example.com>', 'Paul F <paul@example.com>'),
+    ('Paul (hello) <paul@example.com>', 'Paul <paul@example.com>'),
+    ('Paul F (hello) <paul@example.com>', 'Paul F <paul@example.com>'),
+    ('Paul F () <paul@example.com>', 'Paul F <paul@example.com>'),
+    ('Paul F <paul@example.com>', 'Paul F <paul@example.com>'),
+    ('paul@example.com', 'paul@example.com'),
+]
+
+
+def test_parse_email_line():
+    for raw, expected in EMAIL_LINE_CASES:
+        yield assert_equal, expected, PGPKey._parse_uid_as_email_line(raw)

--- a/expirybot/test_pgp_key.py
+++ b/expirybot/test_pgp_key.py
@@ -2,6 +2,13 @@ from .pgp_key import PGPKey
 from nose.tools import assert_equal
 
 
+EMAIL_CASES = [
+    ('Paul F <paul@example.com>', 'paul@example.com'),
+    ('Paul F (hello) <paul@example.com>', 'paul@example.com'),
+    ('Paul F () <paul@example.com>', 'paul@example.com'),
+    ('Paul F <paul@example.com>', 'paul@example.com'),
+]
+
 EMAIL_LINE_CASES = [
     ('Paul F <paul@example.com>', 'Paul F <paul@example.com>'),
     ('Paul (hello) <paul@example.com>', 'Paul <paul@example.com>'),
@@ -15,3 +22,8 @@ EMAIL_LINE_CASES = [
 def test_parse_email_line():
     for raw, expected in EMAIL_LINE_CASES:
         yield assert_equal, expected, PGPKey._parse_uid_as_email_line(raw)
+
+
+def test_parse_uid_as_email():
+    for raw, expected in EMAIL_CASES:
+        yield assert_equal, expected, PGPKey._parse_uid_as_email(raw)

--- a/expirybot/test_send_emails.py
+++ b/expirybot/test_send_emails.py
@@ -19,7 +19,7 @@ class TestExpiryEmailClass(unittest.TestCase):
             fingerprint='A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517',
             algorithm_number=1,
             size_bits=4096,
-            uids='Paul Furley <paul1@example.com>|Paul <paul2@example.com',
+            uids='Paul F <paul1@example.com>|Paul (new) <paul2@example.com>',
             expiry_date=datetime.date(2017, 12, 4),
             created_date=None
         )
@@ -59,7 +59,7 @@ class TestExpiryEmailClass(unittest.TestCase):
 
     def test_to(self):
         assert_equal(
-            'paul1@example.com',
+            'Paul F <paul1@example.com>, Paul <paul2@example.com>',
             self.expiry_email.to
         )
 


### PR DESCRIPTION
- Add PGP.email_lines property
- Add tests for _parse_uid_as_email
- Rename _parse_email -> _parse_uid_as_email
- Add PGPKey._parse_uid_as_email_line(uid)
- It creates to: lines suitable for use with SMTP / Mailgun